### PR TITLE
Feature/invitation onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ flowchart LR
 - Event-driven architecture
 - Queue-based async processing
 - Real-time broadcasting
+- Tenant-aware workspaces and invitation onboarding
 
 ---
 
@@ -223,6 +224,7 @@ git push
 - /docs/api (Scramble)
 - OpenAPI JSON available
 - [Repository Doc](./docs/README.md)
+- [Tenant Invitation Onboarding](./docs/tenancy-invitations.md)
 
 ---
 

--- a/app/Domain/Auth/Services/AuthService.php
+++ b/app/Domain/Auth/Services/AuthService.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Hashing\HashManager;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\PersonalAccessToken;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -29,20 +30,25 @@ class AuthService
     public function register(RegisterUserDTO $dto): AuthenticatedUserDTO
     {
         return DB::transaction(function () use ($dto) {
-            $user = User::create([
-                'name' => $dto->name,
-                'email' => $dto->email,
-                'password' => $this->hash->make($dto->password),
-            ]);
+            $user = $this->createUser($dto);
 
-            $role = Role::firstOrCreate(['name' => 'user', 'guard_name' => 'web']);
-            $user->assignRole($role);
+            return $this->buildAuthenticatedUserDTO($user);
+        });
+    }
 
-            $this->assignDefaultPermissions($user);
-            $this->tenancyService->ensurePersonalTenant($user);
+    public function registerFromInvitation(RegisterUserDTO $dto, string $token): AuthenticatedUserDTO
+    {
+        return DB::transaction(function () use ($dto, $token) {
+            if (User::query()->where('email', $dto->email)->exists()) {
+                throw ValidationException::withMessages([
+                    'email' => ['An account already exists for this invitation email. Please sign in and accept the invitation.'],
+                ]);
+            }
 
-            event(new UserRegistered($user));
-            event(new UserAuthenticated($user, 'password'));
+            $user = $this->createUser($dto);
+            $this->tenancyService->acceptInvitation($user, $token);
+
+            $user->loadMissing('currentTenant');
 
             return $this->buildAuthenticatedUserDTO($user);
         });
@@ -126,5 +132,25 @@ class AuthService
         }
 
         return $guard;
+    }
+
+    protected function createUser(RegisterUserDTO $dto): User
+    {
+        $user = User::query()->create([
+            'name' => $dto->name,
+            'email' => $dto->email,
+            'password' => $this->hash->make($dto->password),
+        ]);
+
+        $role = Role::firstOrCreate(['name' => 'user', 'guard_name' => 'web']);
+        $user->assignRole($role);
+
+        $this->assignDefaultPermissions($user);
+        $this->tenancyService->ensurePersonalTenant($user);
+
+        event(new UserRegistered($user));
+        event(new UserAuthenticated($user, 'password'));
+
+        return $user;
     }
 }

--- a/app/Domain/Tenancy/Services/TenancyService.php
+++ b/app/Domain/Tenancy/Services/TenancyService.php
@@ -15,6 +15,27 @@ use Illuminate\Validation\ValidationException;
 
 class TenancyService
 {
+    public function invitationByToken(string $token): ?TenantInvitation
+    {
+        return TenantInvitation::query()
+            ->with('tenant')
+            ->where('token', $token)
+            ->first();
+    }
+
+    public function invitationByTokenOrFail(string $token): TenantInvitation
+    {
+        $invitation = $this->invitationByToken($token);
+
+        if ($invitation === null) {
+            throw ValidationException::withMessages([
+                'token' => ['The tenant invitation is invalid or no longer available.'],
+            ]);
+        }
+
+        return $invitation;
+    }
+
     public function ensurePersonalTenant(User $user): Tenant
     {
         if ($user->currentTenant !== null) {
@@ -271,9 +292,7 @@ class TenancyService
 
     public function acceptInvitation(User $user, string $token): TenantInvitation
     {
-        $invitation = TenantInvitation::query()
-            ->where('token', $token)
-            ->first();
+        $invitation = $this->invitationByToken($token);
 
         if ($invitation === null || ! $invitation->isPending()) {
             throw ValidationException::withMessages([

--- a/app/Http/Controllers/Api/V1/TenantInvitationController.php
+++ b/app/Http/Controllers/Api/V1/TenantInvitationController.php
@@ -2,11 +2,17 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Domain\Auth\DTOs\RegisterUserDTO;
+use App\Domain\Auth\Services\AuthService;
 use App\Domain\Tenancy\Services\TenancyService;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Tenancy\RegisterFromInvitationRequest;
 use App\Http\Requests\Tenancy\StoreTenantInvitationRequest;
+use App\Http\Resources\Auth\AuthResource;
+use App\Http\Resources\Tenancy\TenantInvitationPreviewResource;
 use App\Http\Resources\Tenancy\TenantInvitationResource;
 use App\Models\TenantInvitation;
+use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -14,7 +20,18 @@ class TenantInvitationController extends Controller
 {
     public function __construct(
         protected TenancyService $tenancyService,
+        protected AuthService $authService,
     ) {}
+
+    public function show(string $token): JsonResponse
+    {
+        $invitation = $this->tenancyService->invitationByTokenOrFail($token);
+
+        return response()->json([
+            'data' => new TenantInvitationPreviewResource($invitation),
+            'meta' => [],
+        ]);
+    }
 
     public function index(Request $request): JsonResponse
     {
@@ -76,6 +93,21 @@ class TenantInvitationController extends Controller
         ]);
     }
 
+    public function register(RegisterFromInvitationRequest $request, string $token): JsonResponse
+    {
+        $invitation = $this->tenancyService->invitationByTokenOrFail($token);
+        $authenticatedUser = $this->authService->registerFromInvitation(
+            new RegisterUserDTO(
+                name: $request->validated('name'),
+                email: $invitation->email,
+                password: $request->validated('password'),
+            ),
+            $token,
+        );
+
+        return $this->authenticatedResponse($authenticatedUser->userId, $authenticatedUser->token, 201);
+    }
+
     public function destroy(Request $request, TenantInvitation $tenantInvitation): JsonResponse
     {
         $tenant = $request->user()->currentTenantOrFail();
@@ -89,5 +121,23 @@ class TenantInvitationController extends Controller
                 'message' => 'Tenant invitation revoked successfully.',
             ],
         ]);
+    }
+
+    protected function authenticatedResponse(int $userId, string $token, int $status = 200): JsonResponse
+    {
+        $user = User::query()
+            ->with(['roles', 'permissions', 'currentTenant'])
+            ->findOrFail($userId);
+        $user->currentTenantOrFail();
+
+        return response()->json([
+            'data' => [
+                'user' => new AuthResource($user),
+                'token' => $token,
+            ],
+            'meta' => [
+                'token_type' => 'Bearer',
+            ],
+        ], $status);
     }
 }

--- a/app/Http/Requests/Tenancy/RegisterFromInvitationRequest.php
+++ b/app/Http/Requests/Tenancy/RegisterFromInvitationRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Tenancy;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class RegisterFromInvitationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'password' => ['required', 'string', Password::defaults()],
+        ];
+    }
+}

--- a/app/Http/Resources/Tenancy/TenantInvitationPreviewResource.php
+++ b/app/Http/Resources/Tenancy/TenantInvitationPreviewResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\Tenancy;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TenantInvitationPreviewResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'email' => $this->resource->email,
+            'role' => $this->resource->role,
+            'permissions' => config('tenancy.membership_roles.' . $this->resource->role, []),
+            'status' => $this->resource->status(),
+            'is_pending' => $this->resource->isPending(),
+            'tenant' => [
+                'id' => $this->resource->tenant?->id,
+                'name' => $this->resource->tenant?->name,
+                'slug' => $this->resource->tenant?->slug,
+            ],
+            'expires_at' => $this->resource->expires_at?->toISOString(),
+            'accepted_at' => $this->resource->accepted_at?->toISOString(),
+            'revoked_at' => $this->resource->revoked_at?->toISOString(),
+            'created_at' => $this->resource->created_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Resources/Tenancy/TenantInvitationPreviewResource.php
+++ b/app/Http/Resources/Tenancy/TenantInvitationPreviewResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Tenancy;
 
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -12,21 +13,47 @@ class TenantInvitationPreviewResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $hasExistingAccount = User::query()
+            ->where('email', $this->resource->email)
+            ->exists();
+        $status = $this->resource->status();
+
         return [
             'email' => $this->resource->email,
             'role' => $this->resource->role,
             'permissions' => config('tenancy.membership_roles.' . $this->resource->role, []),
-            'status' => $this->resource->status(),
+            'status' => $status,
             'is_pending' => $this->resource->isPending(),
+            'has_existing_account' => $hasExistingAccount,
+            'recommended_action' => $this->recommendedAction($status, $hasExistingAccount),
             'tenant' => [
                 'id' => $this->resource->tenant?->id,
                 'name' => $this->resource->tenant?->name,
                 'slug' => $this->resource->tenant?->slug,
+            ],
+            'links' => [
+                'accept' => $this->resource->frontendAcceptUrl(),
+                'register' => $this->resource->frontendRegisterUrl(),
+                'login' => $this->resource->frontendLoginUrl(),
+                'api' => [
+                    'show' => route('api.v1.tenants.invitations.show', ['token' => $this->resource->token]),
+                    'register' => route('api.v1.tenants.invitations.register', ['token' => $this->resource->token]),
+                    'accept' => route('api.v1.tenants.invitations.accept', ['token' => $this->resource->token]),
+                ],
             ],
             'expires_at' => $this->resource->expires_at?->toISOString(),
             'accepted_at' => $this->resource->accepted_at?->toISOString(),
             'revoked_at' => $this->resource->revoked_at?->toISOString(),
             'created_at' => $this->resource->created_at?->toISOString(),
         ];
+    }
+
+    protected function recommendedAction(string $status, bool $hasExistingAccount): ?string
+    {
+        if ($status !== 'pending') {
+            return null;
+        }
+
+        return $hasExistingAccount ? 'login' : 'register';
     }
 }

--- a/app/Models/TenantInvitation.php
+++ b/app/Models/TenantInvitation.php
@@ -64,4 +64,23 @@ class TenantInvitation extends Model
             && $this->revoked_at === null
             && ($expiresAt === null || ($expiresAt instanceof Carbon && $expiresAt->isFuture()));
     }
+
+    public function status(): string
+    {
+        if ($this->accepted_at !== null) {
+            return 'accepted';
+        }
+
+        if ($this->revoked_at !== null) {
+            return 'revoked';
+        }
+
+        $expiresAt = $this->expires_at;
+
+        if ($expiresAt instanceof Carbon && $expiresAt->isPast()) {
+            return 'expired';
+        }
+
+        return 'pending';
+    }
 }

--- a/app/Models/TenantInvitation.php
+++ b/app/Models/TenantInvitation.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
 
 #[Fillable([
     'tenant_id',
@@ -82,5 +83,32 @@ class TenantInvitation extends Model
         }
 
         return 'pending';
+    }
+
+    public function frontendAcceptUrl(): string
+    {
+        return $this->replaceToken((string) config('tenancy.invitations.accept_url'));
+    }
+
+    public function frontendRegisterUrl(): string
+    {
+        return $this->appendTokenToUrl((string) config('tenancy.invitations.register_url'));
+    }
+
+    public function frontendLoginUrl(): string
+    {
+        return $this->appendTokenToUrl((string) config('tenancy.invitations.login_url'));
+    }
+
+    protected function appendTokenToUrl(string $url): string
+    {
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return $this->replaceToken(Str::contains($url, '{token}') ? $url : $url . $separator . 'invitation=' . $this->token);
+    }
+
+    protected function replaceToken(string $url): string
+    {
+        return str_replace('{token}', $this->token, $url);
     }
 }

--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -35,5 +35,7 @@ return [
     'invitations' => [
         'default_expiration_hours' => 168,
         'accept_url' => env('TENANCY_INVITATION_ACCEPT_URL', rtrim((string) env('APP_URL', 'http://localhost'), '/') . '/invitations/{token}'),
+        'login_url' => env('TENANCY_INVITATION_LOGIN_URL', rtrim((string) env('APP_URL', 'http://localhost'), '/') . '/login'),
+        'register_url' => env('TENANCY_INVITATION_REGISTER_URL', rtrim((string) env('APP_URL', 'http://localhost'), '/') . '/register'),
     ],
 ];

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory contains the long-term technical documentation for the NWL API pr
 - [Architecture](./architecture.md)
 - [API Standards](./api-standards.md)
 - [Security](./security.md)
+- [Tenant Invitation Onboarding](./tenancy-invitations.md)
 - [FiveM Bridge](./fivem-bridge.md)
 - [Testing Strategy](./testing-strategy.md)
 - [Deployment](./deployment.md)

--- a/docs/tenancy-invitations.md
+++ b/docs/tenancy-invitations.md
@@ -1,0 +1,131 @@
+# Tenant Invitation Onboarding
+
+## Goal
+
+Provide a clear API contract for tenant invitations so the panel can support:
+
+- invitation preview by token
+- invited-user registration
+- existing-user acceptance after sign-in
+
+## Public endpoints
+
+### Preview invitation
+
+`GET /api/v1/tenants/invitations/{token}`
+
+Purpose:
+
+- inspect invitation state without authentication
+- determine whether the frontend should guide the user to register or log in
+
+Response shape:
+
+```json
+{
+  "data": {
+    "email": "invitee@example.com",
+    "role": "support",
+    "permissions": ["view users"],
+    "status": "pending",
+    "is_pending": true,
+    "has_existing_account": false,
+    "recommended_action": "register",
+    "tenant": {
+      "id": 1,
+      "name": "Operations Workspace",
+      "slug": "operations-workspace"
+    },
+    "links": {
+      "accept": "https://panel.example.com/invitations/<token>",
+      "register": "https://panel.example.com/register?invitation=<token>",
+      "login": "https://panel.example.com/login?invitation=<token>",
+      "api": {
+        "show": "https://api.example.com/api/v1/tenants/invitations/<token>",
+        "register": "https://api.example.com/api/v1/tenants/invitations/<token>/register",
+        "accept": "https://api.example.com/api/v1/tenants/invitations/<token>/accept"
+      }
+    },
+    "expires_at": "2026-04-30T10:00:00Z",
+    "accepted_at": null,
+    "revoked_at": null,
+    "created_at": "2026-04-23T10:00:00Z"
+  },
+  "meta": {}
+}
+```
+
+### Register from invitation
+
+`POST /api/v1/tenants/invitations/{token}/register`
+
+Request body:
+
+```json
+{
+  "name": "Invited User",
+  "password": "password123"
+}
+```
+
+Rules:
+
+- the invited email comes from the invitation, not from the client payload
+- the invitation must still be pending
+- if an account already exists for the invited email, the API returns validation errors and the frontend should redirect to login
+
+Success result:
+
+- creates the user
+- accepts the invitation
+- switches the user into the invited tenant
+- returns auth token and tenant context immediately
+
+### Accept invitation as an existing authenticated user
+
+`POST /api/v1/tenants/invitations/{token}/accept`
+
+Rules:
+
+- requires authentication
+- authenticated user email must match the invitation email
+- invitation must still be pending
+
+## Invitation states
+
+Supported `status` values:
+
+- `pending`
+- `accepted`
+- `revoked`
+- `expired`
+
+Frontend behavior should be based on `status` first and `recommended_action` second.
+
+## Frontend handoff rules
+
+When `status` is `pending`:
+
+- if `recommended_action` is `register`, send the user through the invitation registration flow
+- if `recommended_action` is `login`, send the user through sign-in and then call the authenticated accept endpoint
+
+When `status` is not `pending`:
+
+- do not offer accept/register actions
+- render a terminal state based on the invitation status
+
+## Configuration
+
+The invitation preview resource exposes frontend links built from:
+
+- `TENANCY_INVITATION_ACCEPT_URL`
+- `TENANCY_INVITATION_REGISTER_URL`
+- `TENANCY_INVITATION_LOGIN_URL`
+
+These map to:
+
+- `tenancy.invitations.accept_url`
+- `tenancy.invitations.register_url`
+- `tenancy.invitations.login_url`
+
+Use `{token}` in configured URLs when the frontend route expects path substitution.

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ Route::prefix('v1')
     ->group(function () {
         Route::middleware('throttle:60,1')->group(function () {
             require __DIR__ . '/api/v1/public/auth.php';
+            require __DIR__ . '/api/v1/public/tenants.php';
         });
 
         Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {

--- a/routes/api/v1/public/tenants.php
+++ b/routes/api/v1/public/tenants.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Http\Controllers\Api\V1\TenantInvitationController;
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('tenants')
+    ->name('tenants.')
+    ->controller(TenantInvitationController::class)
+    ->group(function () {
+        Route::get('/invitations/{token}', 'show')->name('invitations.show');
+        Route::post('/invitations/{token}/register', 'register')->name('invitations.register');
+    });

--- a/tests/Feature/TenancyTest.php
+++ b/tests/Feature/TenancyTest.php
@@ -326,6 +326,59 @@ it('resends a pending tenant invitation', function (): void {
     Notification::assertCount(2);
 });
 
+it('shows a public tenant invitation preview by token', function (): void {
+    $owner = User::factory()->create();
+    $service = app(TenancyService::class);
+    $tenant = $service->ensurePersonalTenant($owner);
+    $invitation = $service->createInvitation($owner, 'invitee@example.com', 'support', 24);
+
+    getJson('/api/v1/tenants/invitations/' . $invitation->token)->assertOk()
+        ->assertJsonPath('data.email', 'invitee@example.com')
+        ->assertJsonPath('data.role', 'support')
+        ->assertJsonPath('data.status', 'pending')
+        ->assertJsonPath('data.tenant.id', $tenant->id)
+        ->assertJsonPath('data.tenant.name', $tenant->name);
+});
+
+it('registers a new invited user and accepts the tenant invitation', function (): void {
+    $owner = User::factory()->create();
+    $service = app(TenancyService::class);
+    $tenant = $service->ensurePersonalTenant($owner);
+    $invitation = $service->createInvitation($owner, 'invitee@example.com', 'support', 24);
+
+    postJson('/api/v1/tenants/invitations/' . $invitation->token . '/register', [
+        'name' => 'Invited User',
+        'password' => 'password123',
+    ])->assertCreated()
+        ->assertJsonPath('data.user.email', 'invitee@example.com')
+        ->assertJsonPath('data.user.current_tenant.id', $tenant->id)
+        ->assertJsonPath('data.user.current_tenant.membership_role', 'support')
+        ->assertJsonPath('meta.token_type', 'Bearer');
+
+    $user = User::query()->where('email', 'invitee@example.com')->firstOrFail();
+
+    expect($user->current_tenant_id)->toBe($tenant->id);
+    expect($tenant->users()->whereKey($user->id)->exists())->toBeTrue();
+    expect($user->tenantMembershipRole($tenant))->toBe('support');
+    expect($invitation->fresh()?->accepted_by_user_id)->toBe($user->id);
+});
+
+it('prevents registering from an invitation when the email already has an account', function (): void {
+    $owner = User::factory()->create();
+    $existingUser = User::factory()->create([
+        'email' => 'invitee@example.com',
+    ]);
+    $service = app(TenancyService::class);
+    $service->ensurePersonalTenant($owner);
+    $invitation = $service->createInvitation($owner, $existingUser->email, 'support', 24);
+
+    postJson('/api/v1/tenants/invitations/' . $invitation->token . '/register', [
+        'name' => 'Invited User',
+        'password' => 'password123',
+    ])->assertStatus(422)
+        ->assertJsonValidationErrors(['email']);
+});
+
 it('accepts a tenant invitation for the authenticated user', function (): void {
     $owner = User::factory()->create();
     $invitee = User::factory()->create([

--- a/tests/Feature/TenancyTest.php
+++ b/tests/Feature/TenancyTest.php
@@ -336,8 +336,29 @@ it('shows a public tenant invitation preview by token', function (): void {
         ->assertJsonPath('data.email', 'invitee@example.com')
         ->assertJsonPath('data.role', 'support')
         ->assertJsonPath('data.status', 'pending')
+        ->assertJsonPath('data.has_existing_account', false)
+        ->assertJsonPath('data.recommended_action', 'register')
         ->assertJsonPath('data.tenant.id', $tenant->id)
-        ->assertJsonPath('data.tenant.name', $tenant->name);
+        ->assertJsonPath('data.tenant.name', $tenant->name)
+        ->assertJsonPath('data.links.accept', $invitation->frontendAcceptUrl())
+        ->assertJsonPath('data.links.api.show', url('/api/v1/tenants/invitations/' . $invitation->token))
+        ->assertJsonPath('data.links.api.register', url('/api/v1/tenants/invitations/' . $invitation->token . '/register'))
+        ->assertJsonPath('data.links.api.accept', url('/api/v1/tenants/invitations/' . $invitation->token . '/accept'));
+});
+
+it('shows login as the recommended action when the invited email already has an account', function (): void {
+    $owner = User::factory()->create();
+    User::factory()->create([
+        'email' => 'invitee@example.com',
+    ]);
+    $service = app(TenancyService::class);
+    $service->ensurePersonalTenant($owner);
+    $invitation = $service->createInvitation($owner, 'invitee@example.com', 'support', 24);
+
+    getJson('/api/v1/tenants/invitations/' . $invitation->token)->assertOk()
+        ->assertJsonPath('data.has_existing_account', true)
+        ->assertJsonPath('data.recommended_action', 'login')
+        ->assertJsonPath('data.links.login', $invitation->frontendLoginUrl());
 });
 
 it('registers a new invited user and accepts the tenant invitation', function (): void {


### PR DESCRIPTION
## Summary

Complete the tenant invitation onboarding flow so invited users can enter the SaaS cleanly from an invitation token.

This PR adds:
- public invitation preview by token
- invited-user registration from an invitation
- invitation handoff metadata for the frontend (`status`, `recommended_action`, frontend/API links)
- documentation for the invitation onboarding contract

It also keeps the existing authenticated invitation acceptance flow intact and tenant-aware.

## Type of change

- [x] Feature
- [ ] Fix
- [x] Refactor
- [x] Docs
- [x] Test
- [ ] Chore

## Impact

- [ ] Database / migrations
- [ ] Cache
- [ ] Queue
- [ ] Broadcasting / Reverb
- [x] API contract
- [ ] Localization
- [ ] None of the above

## Testing

Tested:
- public invitation preview endpoint
- invitation preview for existing-account vs new-account scenarios
- register-from-invitation flow
- authenticated invitation acceptance flow
- revoked / invalid / mismatched invitation edge cases

Commands run:
- `composer format`
- `composer run analyse`
- `php artisan test`
- `php artisan test tests/Feature/TenancyTest.php`

## Checklist

- [x] I wrote everything in English
- [x] I ran Pint
- [x] I ran PHPStan
- [x] I ran Pest
- [x] I updated documentation when needed
- [ ] I updated localization keys when needed
- [x] I did not commit secrets
